### PR TITLE
Don't unwrap @extend or @mixin

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ var rule = function (rule) {
             unwrapped = true;
             child.selector = selector(rule, child);
             after = child.moveAfter(after);
-        } else if ( child.type == 'atrule' ) {
+        } else if ( child.type == 'atrule' && child.nodes !== undefined ) {
             unwrapped = true;
             atruleChilds(rule, child);
             after = child.moveAfter(after);

--- a/test/test.js
+++ b/test/test.js
@@ -50,6 +50,11 @@ describe('postcss-nested', function () {
               '@media screen {\n    a b {\n        color: black\n    }\n}');
     });
 
+    it('doesnt unwrap at-extends', function () {
+        check('a { color: black; @extend foo; }',
+              'a { color: black; @extend foo; }');
+    });
+
     it('unwraps at-rules', function () {
         check('a { a: 1 } a { @media screen { @supports (a: 1) { a: 1 } } }',
               'a { a: 1 } @media screen { @supports (a: 1) { a { a: 1 } } }');


### PR DESCRIPTION
This plugin's behaviour is correct when dealing with at-rules like `@media` and `@supports`, but other postcss plugins like [postcss-simple-extend](https://github.com/davidtheclark/postcss-simple-extend) and [postcss-mixins](https://github.com/postcss/postcss-mixins) both use at-rules to signify something. Unwrapping them changes their semantics, in fact postcss-mixins includes this phrase in its readme:

> Note, that you must set this plugin before postcss-simple-vars and postcss-nested.

postcss-simple-extend, on the other hand, declares:

> @extend must not occur at the root level: only inside rule sets.

That means that the unwrapping behaviour for postcss-nested actually crashes postcss-simple-extend. Unlike mixins, `@extend` needs the full selector to be able to work, so can't run before nested.

This PR simply checks if the at-rule has no child block defined. According to the [API](https://github.com/postcss/postcss/blob/master/API.md#atrule-node) this will occur for cases such as:

```css
tag { @rule; }
```

but not for:

```css
tag { @rule { } }
```

which is what we want. In the latter case, `child.nodes` returns `[]`, in the former it returns `undefined`. So I've added that guard and a corresponding test case.

Thanks!