### PR TITLE
generate correct styles when &, nest, adjacent

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,9 @@ function selectors(parent, node) {
             if ( j.indexOf('&') === -1 ) {
                 result.push(i + ' ' + j);
             } else {
-                result.push(j.replace(/&/g, i));
+                result.push(j.replace('&', i)
+                            .replace(/&/g, postcss.list.space(i).pop())
+                );
             }
         });
     });

--- a/test/test.js
+++ b/test/test.js
@@ -96,6 +96,11 @@ describe('postcss-nested', function () {
               '@media {\n    a {\n        /*B*/\n        one: 1\n    }\n}');
     });
 
+    it('unwrap rules inside rules with adjacent selector and &', function () {
+        check('.parent { .adjacent { &-left+&-right { margin: 0; } } }',
+              '.parent .adjacent-left+.adjacent-right {\n    margin: 0;\n}');
+    });
+
     it('parses example', function () {
         var input =  '.phone {\n' +
                      '    &_title {\n' +


### PR DESCRIPTION
``` scss
.parent {
  .adjacent {
    &-left+&-right {
      background-color: black;
    }
  }
  .adjacent-left+.adjacent-right {
    background-color: black;
  }
}
```

compile

``` css
/* Error, it will never work */
.parent .adjacent-left + .parent .adjacent-right {
  background-color: black;
}
/* Correct */
.parent .adjacent-left + .adjacent-right {
  background-color: black;
}
```

fix this bug. [error demo](https://jsfiddle.net/ms6q4rqj/1/)
