### PR TITLE
account for one-line atrules.

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,8 +31,12 @@ function atruleChilds(rule, atrule) {
             children.push( child );
         } else if ( child.type === 'rule' ) {
             child.selectors = selectors(rule, child);
-        } else if ( child.type === 'atrule' ) {
-            atruleChilds(rule, child);
+        } else if ( child.type === 'atrule') {
+            if (/include/.test(child.name) && !child.nodes) {
+                children.push(child);
+            } else {
+                atruleChilds(rule, child);
+            }
         }
     });
     if ( children.length ) {

--- a/test/test.js
+++ b/test/test.js
@@ -54,6 +54,11 @@ describe('postcss-nested', function () {
               'a { a: 1 } @media screen { @supports (a: 1) { a { a: 1 } } }');
     });
 
+    it('handles one line at-rules', function () {
+        check('a { @media screen { @include b; } }',
+              '@media screen {\n    a {\n        @include b\n    }\n}');
+    });
+
     it('do not move custom at-rules', function () {
         check('.one { @mixin test; } .two { @phone { color: black } }',
               '.one { @mixin test; } @phone { .two { color: black } }',


### PR DESCRIPTION
This accounts for one-line `atrules`, e.g. `@include cssBorder`. I know this may be out of scope for the plugin, but I figured I'd at least start a conversation here. 

It looks like without this patch that one line `atrules` just end up "orphaned" in their parent `atrule`.