### PR TITLE
fix(*): fix for adjacent sibling selector

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,8 @@ var parser = require('postcss-selector-parser');
 
 function concatNested(selector, parent) {
     var replaced = false;
-
-    selector.walkNesting(function (ampersand) {
+    var nestingNodes = selector.nodes.filter(node => node.type === 'nesting');
+    nestingNodes.forEach(ampersand => {
         ampersand.replaceWith(parent.clone());
         replaced = true;
     });

--- a/index.test.js
+++ b/index.test.js
@@ -125,3 +125,9 @@ it('does not replace ampersand inside string', () => {
         'div { &[data-category="sound & vision"] {} }',
         'div[data-category="sound & vision"] {}');
 });
+
+it('should replace ampersand in adjacent sibling selector', () => {
+    return run(
+        'div { & + & {} }',
+        'div + div {}');
+});


### PR DESCRIPTION
bug in 2.0.3, see test and PR
```
selector.walkNesting(function (ampersand) {
```
working incorrectly, as I understand 