### PR TITLE
Upgraded postcss-selector-parser which no longer has es6 dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "repository": "postcss/postcss-nested",
   "dependencies": {
     "postcss": "^6.0.14",
-    "postcss-selector-parser": "^3.1.1"
+    "postcss-selector-parser": "^3.1.2"
   },
   "devDependencies": {
     "eslint": "^4.13.0",


### PR DESCRIPTION
This resolves #71 