### PR TITLE
Bump version to 3.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-nested",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "PostCSS plugin to unwrap nested rules like how Sass does it.",
   "keywords": [
     "postcss",


### PR DESCRIPTION
A version number published on npm is the same as version is in repo - 3.0.0
But a code base is different. NPM's version has "postcss": "^6.0.14" in dependencies while GitHub version depends on "postcss": "^7.0.2"
Please bump version number and publish package on npm

Thanks!