### PR TITLE
Fixes #79. Adds support for params adjacent to nesting selector.

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,16 @@ function replace (nodes, parent) {
   var replaced = false
   nodes.each(function (i) {
     if (i.type === 'nesting') {
-      i.replaceWith(parent.clone())
+      // clone the parent node
+      var clonedParent = parent.clone()
+      // if the current node has a nesting selector with params
+      var hasParameters = i.value.match(/&\((.*?)\)/)
+      if (hasParameters) {
+        // append the params to the last selector in the cloned parent
+        clonedParent.last.value += '(' + hasParameters[1] + ')'
+      }
+      // replace the current node with the parent
+      i.replaceWith(clonedParent)
       replaced = true
     } else if (i.nodes) {
       if (replace(i, parent)) {

--- a/index.test.js
+++ b/index.test.js
@@ -166,3 +166,7 @@ it('replaces ampersand in adjacent sibling selector', function () {
 it('replaces ampersands in not selector', function () {
   return run('.a { &:not(&.no) {} }', '.a:not(.a.no) {}')
 })
+
+it('handles :host selector case', function () {
+  return run(':host { &(:focus) {} }', ':host(:focus) {}')
+})


### PR DESCRIPTION
This is the cleanest fix I could come up with.

The parsed selector nodes for nesting with parenthesis, e.g. &(:focus) end up coming out in the parsed node with the parens attached to the ampersand. So we have to clone the parent node, and then inject the parens back into the last selector in the cloned parent node.

Let me know if I'm missing something, but this seems to work.