### PR TITLE
Fix nested tail ampersands

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,7 +132,7 @@ module.exports = (opts = {}) => {
 
   return {
     postcssPlugin: 'postcss-nested',
-    RuleExit (rule, { Rule }) {
+    Rule (rule, { Rule }) {
       let unwrapped = false
       let after = rule
       let copyDeclarations = false
@@ -152,8 +152,6 @@ module.exports = (opts = {}) => {
           after.after(child)
           after = child
         } else if (child.type === 'atrule') {
-          copyDeclarations = false
-
           if (declarations.length) {
             after = pickDeclarations(rule.selector, declarations, after, Rule)
             declarations = []
@@ -172,17 +170,21 @@ module.exports = (opts = {}) => {
             after = nodes
             child.remove()
           } else if (bubble[child.name]) {
+            copyDeclarations = true
             unwrapped = true
             atruleChilds(rule, child, true)
             after = pickComment(child.prev(), after)
             after.after(child)
             after = child
           } else if (unwrap[child.name]) {
+            copyDeclarations = true
             unwrapped = true
             atruleChilds(rule, child, false)
             after = pickComment(child.prev(), after)
             after.after(child)
             after = child
+          } else if (copyDeclarations) {
+            declarations.push(child)
           }
         } else if (child.type === 'decl' && copyDeclarations) {
           declarations.push(child)

--- a/index.test.js
+++ b/index.test.js
@@ -55,7 +55,7 @@ it('unwrap rules inside at-rules', () => {
 it('unwraps at-rule', () => {
   run(
     'a { b { @media screen { width: auto } } }',
-    '@media screen { a b { width: auto } }'
+    '@media screen {a b { width: auto } }'
   )
 })
 

--- a/index.test.js
+++ b/index.test.js
@@ -87,6 +87,13 @@ it('unwraps at-rules', () => {
   )
 })
 
+it('unwraps at-rules with interleaved properties', () => {
+  run(
+    'a { a: 1 } a { color: red; @media screen { @supports (a: 1) { a: 1 } } background: green }',
+    'a { a: 1 } a { color: red; } @media screen { @supports (a: 1) { a { a: 1 } } } a { background: green }'
+  )
+})
+
 it('do not move custom at-rules', () => {
   run(
     '.one { @mixin test; } .two { @phone { color: black } }',
@@ -171,6 +178,25 @@ it('replaces ampersands in not selector', () => {
   run('.a { &:not(&.no) {} }', '.a:not(.a.no) {}')
 })
 
+it('correctly replaces tail ampersands', () => {
+  run('.a { .b & {} }', '.b .a {}')
+})
+
+it('correctly replaces tail ampersands that are nested further down', () => {
+  run('.a { .b { .c & {} } }', '.c .a .b {}')
+})
+
+it('correctly replaces tail ampersands that are nested inside ampersand rules', () => {
+  run('.a { &:hover { .b { .c & {} } } }', '.c .a:hover .b {}')
+})
+
+it('preserves child order when replacing tail ampersands', () => {
+  run(
+    '.a { color: red; .first {} @mixinFirst; .b & {} @mixinLast; .last {} }',
+    '.a { color: red; } .a .first {} .a { @mixinFirst; } .b .a {} .a { @mixinLast; } .a .last {}'
+  )
+})
+
 it('handles :host selector case', () => {
   run(':host { &(:focus) {} }', ':host(:focus) {}')
 })
@@ -190,6 +216,23 @@ it('works with other visitors', () => {
   mixinPlugin.postcss = true
   let out = postcss([plugin, mixinPlugin]).process(css, { from: undefined }).css
   expect(out).toEqual('a b{color:red}a .in .deep{color:blue}')
+})
+
+it('works with other visitors #2', () => {
+  let css = 'a { @mixin; b {color:red} }'
+  let mixinPlugin = () => {
+    return {
+      postcssPlugin: 'mixin',
+      AtRule: {
+        mixin (node) {
+          node.replaceWith('.in { .deep {color:blue} }')
+        }
+      }
+    }
+  }
+  mixinPlugin.postcss = true
+  let out = postcss([plugin, mixinPlugin]).process(css, { from: undefined }).css
+  expect(out).toEqual('a .in .deep {color:blue} a b {color:red}')
 })
 
 it('shows clear errors on missed semicolon', () => {


### PR DESCRIPTION
This fixes #115. It’s a much deeper change than I would have liked, but I see no other way to fix the issue. 

In order for tail ampersands (`a & {…}`) to be replaced correctly, we need to know the parent’s full selector before we can replace the `&`. Therefore we need to do the replacements on the way down (in `Rule`) instead of on the way up (in `RuleExit`).

This has all sorts of implications for plugin execution order. I needed to change how @-rules are handled to make the pre-existing `it works with other visitors` test pass. Otherwise, the fix for the `&` rules would have changed the order of rule declarations in the resulting CSS.

All the existing tests still pass ([except for one whitespace issue; see the last commit](https://github.com/postcss/postcss-nested/commit/1014d8734fe1b1c8bb5ad4e06038f4d8e9086965)) and I’ve added a bunch more to make sure, but you should probably still consider flagging this fix as a breaking change.

