### PR TITLE
Handle root-level ampersands gracefully

### DIFF
--- a/index.test.js
+++ b/index.test.js
@@ -775,4 +775,11 @@ test('The rooRuleName option may start with "@"', () => {
   })
 })
 
+test('selector-less curly-brace blocks are removed from output', () => {
+  run(
+    '{ a {color:white} { b {color:red;} } }',
+    'a {color:white} b {color:red;}'
+  )
+})
+
 test.run()

--- a/index.test.js
+++ b/index.test.js
@@ -782,4 +782,25 @@ test('selector-less curly-brace blocks are removed from output', () => {
   )
 })
 
+test('root-level `&` is removed from output', () => {
+  run(
+    'a {color:white} & { b {color:red;} c & { & { color:green; } } & d {color:blue;} }',
+    'a {color:white} b {color:red;} c {color:green;} d {color:blue;}'
+  )
+})
+
+test('root level `&` inside @media is removed', () => {
+  run(
+    '@media screen { & { a {color:red;} b & {color:green;} } }',
+    '@media screen { a {color:red;} b {color:green;} }'
+  )
+})
+
+test('root level `&` with @media inside is removed', () => {
+  run(
+    '& { @media screen { a {color:red;} b & {color:green;} } }',
+    '@media screen { a {color:red;} b {color:green;} }'
+  )
+})
+
 test.run()


### PR DESCRIPTION
I ran into this inconsitent behavior in the plugin.

After thinking about this for a while, I feel that `postcss-nested` ought to handle this gracefully and treat a root-level `&` selector token the same way it handles the empty selector — i.e. remove the curly block and replace all instances of `&` with the empty string.

(For comparison SASSMeister just errors on both of these cases, so... 🤷)

I ran into this in an actual project where we had mixin/function that got (quite reasonably) applied at the root level in certain cases, and the results felt surprisingly unelegant.

I've added these tests, but I'd be thankful if someone could provide/suggest the required changes in `index.js`.