### PR TITLE
Correction of the work with comments and general improvements

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,31 @@ function mergeSelectors(parent, child) {
  * ! It is necessary to clarify the comment
  */
 function breakOut(child, after) {
-  after.after(child)
+  let changeParent = true
+
+  for (let node of after.nodes) {
+    if (!node.nodes) continue
+
+    let prevNode = node.prev()
+    if (prevNode?.type != 'comment') continue
+
+    let parentRule = after.toString()
+
+    /* Checking that the comment "describes" the rule following. Like this:
+      /* comment about the rule below /*
+      .rule {}
+    */
+    if (parentRule.includes(prevNode.toString() + node.toString())) {
+      changeParent = false
+      after.after(node).after(prevNode)
+    }
+  }
+
+  // It is necessary if the above child has never been moved
+  if (changeParent) {
+    after.after(child)
+  }
+
   return child
 }
 

--- a/index.js
+++ b/index.js
@@ -125,6 +125,17 @@ function pickDeclarations(selector, declarations, after) {
   after.after(parent)
   return parent
 }
+function pickAndClearDeclarations(ruleSelector, declarations, after, clear = true) {
+  if (!declarations.length) return [after, declarations]
+
+  after = pickDeclarations(ruleSelector, declarations, after)
+
+  if (clear) {
+    declarations = []
+  }
+
+  return [after, declarations]
+}
 
 function atruleNames(defaults, custom) {
   let list = {}
@@ -312,10 +323,7 @@ module.exports = (opts = {}) => {
       rule.each(child => {
         switch (child.type) {
           case 'rule':
-            if (declarations.length) {
-              after = pickDeclarations(rule.selector, declarations, after)
-              declarations = []
-            }
+            [after, declarations] = pickAndClearDeclarations(rule.selector, declarations, after)
 
             copyDeclarations = true
             unwrapped = true
@@ -324,10 +332,8 @@ module.exports = (opts = {}) => {
 
             break
           case 'atrule':
-            if (declarations.length) {
-              after = pickDeclarations(rule.selector, declarations, after)
-              declarations = []
-            }
+            [after, declarations] = pickAndClearDeclarations(rule.selector, declarations, after)
+
             if (child.name === rootRuleName) {
               unwrapped = true
               atruleChilds(rule, child, true, child[rootRuleMergeSel])
@@ -356,9 +362,7 @@ module.exports = (opts = {}) => {
         }
       })
 
-      if (declarations.length) {
-        after = pickDeclarations(rule.selector, declarations, after)
-      }
+      pickAndClearDeclarations(rule.selector, declarations, after, false)
 
       if (unwrapped && preserveEmpty !== true) {
         rule.raws.semicolon = true

--- a/index.js
+++ b/index.js
@@ -91,7 +91,9 @@ function breakOut(child, after) {
       /* comment about the rule below /*
       .rule {}
     */
-    if (parentRule.includes(prevNode.toString() + node.toString())) {
+    let regexp = new RegExp(`${prevNode.toString()} *\n *${node.toString()}`)
+
+    if (parentRule.match(regexp)) {
       changeParent = false
       after.after(node).after(prevNode)
     }

--- a/index.js
+++ b/index.js
@@ -53,12 +53,12 @@ function interpolateAmpInSelector(nodes, parent) {
  */
 function mergeSelectors(parent, child) {
   let merged = []
-  parent.selectors.forEach(sel => {
+  for (let sel of parent.selectors) {
     let parentNode = parse(sel, parent)
 
-    child.selectors.forEach(selector => {
+    for (let selector of child.selectors) {
       if (!selector) {
-        return
+        continue
       }
       let node = parse(selector, child)
       let replaced = interpolateAmpInSelector(node, parentNode)
@@ -67,13 +67,13 @@ function mergeSelectors(parent, child) {
         node.prepend(parentNode.clone({}))
       }
       merged.push(node.toString())
-    })
-  })
+    }
+  }
   return merged
 }
 
 /**
- * Move a child and its preceeding comment(s) to after "after"
+ * Move a child and its preceding comment(s) to after "after"
  */
 function breakOut(child, after) {
   let prev = child.prev()
@@ -104,14 +104,12 @@ function createFnAtruleChilds(bubble) {
         children.push(child)
       }
     })
-    if (bubbling) {
-      if (children.length) {
-        let clone = rule.clone({ nodes: [] })
-        for (let child of children) {
-          clone.append(child)
-        }
-        atrule.prepend(clone)
+    if (bubbling && children.length) {
+      let clone = rule.clone({ nodes: [] })
+      for (let child of children) {
+        clone.append(child)
       }
+      atrule.prepend(clone)
     }
   }
 }
@@ -304,10 +302,10 @@ module.exports = (opts = {}) => {
     postcssPlugin: 'postcss-nested',
 
     RootExit(root) {
-      if (root[hasRootRule]) {
-        root.walkAtRules(rootRuleName, unwrapRootRule)
-        root[hasRootRule] = false
-      }
+      if (!root[hasRootRule]) return
+
+      root.walkAtRules(rootRuleName, unwrapRootRule)
+      root[hasRootRule] = false
     },
 
     Rule(rule) {

--- a/index.js
+++ b/index.js
@@ -74,15 +74,10 @@ function mergeSelectors(parent, child) {
 
 /**
  * Move a child and its preceding comment(s) to after "after"
+ * ! It is necessary to clarify the comment
  */
 function breakOut(child, after) {
-  let prev = child.prev()
   after.after(child)
-  while (prev && prev.type === 'comment') {
-    let nextPrev = prev.prev()
-    after.after(prev)
-    prev = nextPrev
-  }
   return child
 }
 

--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ function breakOut(child, after) {
     if (!node.nodes) continue
 
     let prevNode = node.prev()
-    if (prevNode?.type != 'comment') continue
+    if (prevNode?.type !== 'comment') continue
 
     let parentRule = after.toString()
 

--- a/index.js
+++ b/index.js
@@ -310,40 +310,49 @@ module.exports = (opts = {}) => {
       let declarations = []
 
       rule.each(child => {
-        if (child.type === 'rule') {
-          if (declarations.length) {
-            after = pickDeclarations(rule.selector, declarations, after)
-            declarations = []
-          }
+        switch (child.type) {
+          case 'rule':
+            if (declarations.length) {
+              after = pickDeclarations(rule.selector, declarations, after)
+              declarations = []
+            }
 
-          copyDeclarations = true
-          unwrapped = true
-          child.selectors = mergeSelectors(rule, child)
-          after = breakOut(child, after)
-        } else if (child.type === 'atrule') {
-          if (declarations.length) {
-            after = pickDeclarations(rule.selector, declarations, after)
-            declarations = []
-          }
-          if (child.name === rootRuleName) {
-            unwrapped = true
-            atruleChilds(rule, child, true, child[rootRuleMergeSel])
-            after = breakOut(child, after)
-          } else if (bubble[child.name]) {
             copyDeclarations = true
             unwrapped = true
-            atruleChilds(rule, child, true)
+            child.selectors = mergeSelectors(rule, child)
             after = breakOut(child, after)
-          } else if (unwrap[child.name]) {
-            copyDeclarations = true
-            unwrapped = true
-            atruleChilds(rule, child, false)
-            after = breakOut(child, after)
-          } else if (copyDeclarations) {
-            declarations.push(child)
-          }
-        } else if (child.type === 'decl' && copyDeclarations) {
-          declarations.push(child)
+
+            break
+          case 'atrule':
+            if (declarations.length) {
+              after = pickDeclarations(rule.selector, declarations, after)
+              declarations = []
+            }
+            if (child.name === rootRuleName) {
+              unwrapped = true
+              atruleChilds(rule, child, true, child[rootRuleMergeSel])
+              after = breakOut(child, after)
+            } else if (bubble[child.name]) {
+              copyDeclarations = true
+              unwrapped = true
+              atruleChilds(rule, child, true)
+              after = breakOut(child, after)
+            } else if (unwrap[child.name]) {
+              copyDeclarations = true
+              unwrapped = true
+              atruleChilds(rule, child, false)
+              after = breakOut(child, after)
+            } else if (copyDeclarations) {
+              declarations.push(child)
+            }
+
+            break
+          case 'decl':
+            if (copyDeclarations) {
+              declarations.push(child)
+            }
+
+            break
         }
       })
 

--- a/index.js
+++ b/index.js
@@ -137,15 +137,11 @@ function pickAndClearDeclarations(ruleSelector, declarations, after, clear = tru
   return [after, declarations]
 }
 
-function atruleNames(defaults, custom) {
+function atruleNames(defaults, custom = '') {
+  let names = defaults.concat(custom)
   let list = {}
-  for (let name of defaults) {
-    list[name] = true
-  }
-  if (custom) {
-    for (let name of custom) {
-      list[name.replace(/^@/, '')] = true
-    }
+  for (let name of names) {
+    list[name.replace(/^@/, '')] = true
   }
   return list
 }

--- a/index.test.js
+++ b/index.test.js
@@ -609,12 +609,20 @@ test("Save the parent's comment", () => {
 })
 
 test('Save the comment for the parent and child', () => {
-  run('a { /*i*/ /*o*/b {} }', 'a { /*i*/ } /*o*/ a b {}')
+  run(
+    `a { 
+    /*i*/ 
+    /*o*/
+    b {} }`,
+
+    `a { /*i*/ } /*o*/ a b {}`
+  )
 })
 
 test('moves comments with at-rule', () => {
   run(
-    'a { /*i*/ /*o*/@media { one: 1 } }',
+    `a { /*i*/ /*o*/
+    @media { one: 1 } }`,
     'a { /*i*/ } /*o*/ @media {a { one: 1 } }'
   )
 })

--- a/index.test.js
+++ b/index.test.js
@@ -605,15 +605,19 @@ test('clears empty selector after comma', () => {
 })
 
 test('moves comment with rule', () => {
-  run('a { /*B*/ /*B2*/ b {} }', '/*B*/ /*B2*/ a b {}')
+  run('a { /*B*/ /*B2*/ b {} }', 'a { /*B*/ /*B2*/ } a b {}')
 })
 
 test('moves comment with at-rule', () => {
-  run('a { /*B*/ @media { one: 1 } }', '/*B*/ @media {a { one: 1 } }')
+  run('a { /*B*/ @media { one: 1 } }', 'a { /*B*/ } @media {a { one: 1 } }')
 })
 
 test('moves comment with declaration', () => {
   run('a { @media { /*B*/ one: 1 } }', '@media {a { /*B*/ one: 1 } }')
+})
+
+test('moves comment with declaration without properties', () => {
+  run('a { @media { /*B*/ } }', '@media {a { /*B*/ } }')
 })
 
 test('saves order of rules', () => {

--- a/index.test.js
+++ b/index.test.js
@@ -608,6 +608,16 @@ test("Save the parent's comment", () => {
   run('a { /*i*/ b {} }', 'a { /*i*/ } a b {}')
 })
 
+test("Save the parent's comment with newline", () => {
+  run(
+    `a { 
+    /*i*/
+
+     b {} }`,
+    `a { /*i*/ } a b {}`
+  )
+})
+
 test('Save the comments for the parent and child', () => {
   run(
     `a { 

--- a/index.test.js
+++ b/index.test.js
@@ -608,7 +608,7 @@ test("Save the parent's comment", () => {
   run('a { /*i*/ b {} }', 'a { /*i*/ } a b {}')
 })
 
-test('Save the comment for the parent and child', () => {
+test('Save the comments for the parent and child', () => {
   run(
     `a { 
     /*i*/ 
@@ -619,11 +619,13 @@ test('Save the comment for the parent and child', () => {
   )
 })
 
-test('moves comments with at-rule', () => {
+test('Save the comments for the parent and child with at-rule', () => {
   run(
-    `a { /*i*/ /*o*/
+    `a { /*i*/ 
+    /*o*/
     @media { one: 1 } }`,
-    'a { /*i*/ } /*o*/ @media {a { one: 1 } }'
+
+    `a { /*i*/ } /*o*/ @media {a { one: 1 } }`
   )
 })
 

--- a/index.test.js
+++ b/index.test.js
@@ -604,20 +604,27 @@ test('clears empty selector after comma', () => {
   run('a, b { .one, .two, {} }', 'a .one, a .two, b .one, b .two {}')
 })
 
-test('moves comment with rule', () => {
-  run('a { /*B*/ /*B2*/ b {} }', 'a { /*B*/ /*B2*/ } a b {}')
+test("Save the parent's comment", () => {
+  run('a { /*i*/ b {} }', 'a { /*i*/ } a b {}')
 })
 
-test('moves comment with at-rule', () => {
-  run('a { /*B*/ @media { one: 1 } }', 'a { /*B*/ } @media {a { one: 1 } }')
+test('Save the comment for the parent and child', () => {
+  run('a { /*i*/ /*o*/b {} }', 'a { /*i*/ } /*o*/ a b {}')
+})
+
+test('moves comments with at-rule', () => {
+  run(
+    'a { /*i*/ /*o*/@media { one: 1 } }',
+    'a { /*i*/ } /*o*/ @media {a { one: 1 } }'
+  )
 })
 
 test('moves comment with declaration', () => {
-  run('a { @media { /*B*/ one: 1 } }', '@media {a { /*B*/ one: 1 } }')
+  run('a { @media { /*B*/ one: 1 } }', '@media { a { /*B*/ one: 1 } }')
 })
 
 test('moves comment with declaration without properties', () => {
-  run('a { @media { /*B*/ } }', '@media {a { /*B*/ } }')
+  run('a { @media { /*B*/ } }', '@media { a { /*B*/ } }')
 })
 
 test('saves order of rules', () => {


### PR DESCRIPTION
List of changes:

- Fixed a bug where rules with comments without properties could lose comments embedded in them.
- The code that was duplicated several times was deleted and moved to a new function.
- General code improvements: `foreach` has been replaced with `for`, and some methods have been optimized.

**All tests were passed correctly.**