### PR TITLE
Export the plugin name

### DIFF
--- a/index.js
+++ b/index.js
@@ -305,6 +305,8 @@ module.exports = (opts = {}) => {
   let preserveEmpty = opts.preserveEmpty
 
   return {
+    postcssPlugin: 'postcss-nested',
+
     Once(root) {
       root.walkAtRules(rootRuleName, node => {
         normalizeRootRule(node)
@@ -379,4 +381,3 @@ module.exports = (opts = {}) => {
   }
 }
 module.exports.postcss = true
-module.exports.postcssPlugin = 'postcss-nested'

--- a/index.js
+++ b/index.js
@@ -379,3 +379,4 @@ module.exports = (opts = {}) => {
   }
 }
 module.exports.postcss = true
+module.exports.postcssPlugin = 'postcss-nested'


### PR DESCRIPTION
The [typescript-plugin-css-modules](https://www.npmjs.com/package/typescript-plugin-css-modules) rely on [the plugin name](https://github.com/mrmckeb/typescript-plugin-css-modules/blob/dd71f5c82c57b024a80f1e29a8e6a6319a02b130/src/helpers/filterPlugins.ts#L12) to distinguish the plugins to load. It will omit the `postcss-nested` plugin without the exported `postcssPlugin`. Therefore, the IDE does not have intelligence for the nested selectors.